### PR TITLE
Fixed activesupport major version

### DIFF
--- a/fluent-plugin-gamobile.gemspec
+++ b/fluent-plugin-gamobile.gemspec
@@ -15,8 +15,9 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # specify any dependencies here; for example:
-  s.add_development_dependency "fluentd"
+  s.add_development_dependency "rake"
+  s.add_development_dependency "test-unit"
   s.add_runtime_dependency "fluentd"
-  s.add_runtime_dependency "active_support"
+  s.add_runtime_dependency "activesupport", '~> 3.0.0'
   s.add_runtime_dependency "i18n"
 end


### PR DESCRIPTION
update the changed gem name of activesupport.
https://github.com/y-ken/fluent-plugin-gamobile/issues/2

## error

```
# /usr/lib64/fluent/ruby/bin/fluent-gem install fluent-plugin-gamobile
ERROR:  While executing gem ... (Gem::DependencyError)
    Unable to resolve dependencies: fluent-plugin-gamobile requires active_support (>= 0)
```