### PR TITLE
Upgrade activesupport to 7.2.3.1+

### DIFF
--- a/fluent-plugin-gamobile.gemspec
+++ b/fluent-plugin-gamobile.gemspec
@@ -18,11 +18,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "test-unit", '~> 3'
   s.add_development_dependency "appraisal"
   s.add_runtime_dependency "fluentd"
-  s.add_runtime_dependency "activesupport", '~> 6.1.7', '>= 6.1.7.3'
+  s.add_runtime_dependency "activesupport", '~> 7.2', '>= 7.2.3.1'
   s.add_runtime_dependency "i18n"
-  # Required by activesupport on Ruby 3.4+, where these are no longer default gems.
-  s.add_runtime_dependency "bigdecimal"
-  s.add_runtime_dependency "base64"
-  s.add_runtime_dependency "drb"
-  s.add_runtime_dependency "mutex_m"
 end


### PR DESCRIPTION
## Summary

Resolves the new Dependabot alert that requires `activesupport >= 7.2.3.1` ([dependabot/7](https://github.com/y-ken/fluent-plugin-gamobile/security/dependabot/7)).

Bumps the runtime dependency from `~> 6.1.7, >= 6.1.7.3` (merged in #14) to `~> 7.2, >= 7.2.3.1`.

## Compatibility

The plugin only uses `Object#blank?` from `active_support/core_ext`, which is unchanged across these versions, so the upgrade is behavior compatible.

## Dependency cleanup

The `bigdecimal`, `base64`, `drb` and `mutex_m` dependencies that were added for the 6.1 upgrade are removed:

- activesupport 7.x declares `base64` / `bigdecimal` / `drb` as its **own** runtime dependencies, so they are pulled in transitively.
- activesupport 7.1+ no longer uses `mutex_m`.

Verified that the plugin still loads and tests pass on Ruby 3.4 without them.

## Testing

`bundle exec rake test` with activesupport 7.2.3.1 on Ruby 3.4 / fluentd 1.19:

```
2 tests, 4 assertions, 0 failures, 0 errors, 0 pendings
100% passed
```

CI (GitHub Actions) also runs this on Ruby 3.2 / 3.3 / 3.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)